### PR TITLE
RepoReviver: safe dependency update

### DIFF
--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
RepoReviver ran a safe dependency update across this repo.

## What changed
- Bumped dependencies within their existing version ranges (no major version jumps)
- Refreshed lockfiles for each detected package area
- Some build/test failures were auto-repaired by Claude (capped patches, no CI/infra files touched). See per-package details below.

## Per-package results
### client (npm)
- ❌ Install (npm)
- ✅ Install (npm) (after attempt 1)
- ✅ Update deps (npm)
- ✅ Run build
- ✅ Run test

**AI repair attempts:**
- `Install (npm)` → ✅ fixed after 1 attempt(s)
  - Attempt 1: patch applied — files: `client/.npmrc`
    > The issue is that `react-scripts@3.4.0` has a peer dependency of `typescript@^3.2.1`, but the project specifies `typescript@~4.9.5`. Adding an `.npmrc` file with `legacy-peer-deps=true` will allow npm to install without enforcing this peer dependency conflict, which is the safest fix since we can't downgrade TypeScript (it would break the app) or upgrade react-scripts (major version change).

### Repo root (npm)
- ✅ Install (npm)
- ✅ Update deps (npm)

## Verify before merging
- Pull the branch locally
- Run install + tests against your real environment
- **Read the AI repair attempts carefully** — Claude wrote those patches and a human review matters
- If everything looks good, mark the PR ready for review and merge

---
_Opened by [repo-reviver](https://github.com/bradtraversy/repo-reviver-cli)._