### PR TITLE
RepoReviver: safe dependency update

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,8 +33,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
-    "test": "react-scripts test",
+    "build": "SKIP_PREFLIGHT_CHECK=true NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
RepoReviver ran a safe dependency update across this repo.

## What changed
- Bumped dependencies within their existing version ranges (no major version jumps)
- Refreshed lockfiles for each detected package area
- Some build/test failures were auto-repaired by Claude (capped patches, no CI/infra files touched). See per-package details below.

## Per-package results
### Repo root (npm)
- ✅ Install (npm)
- ✅ Update deps (npm)
- ✅ Fresh-install verification

### client (npm)
- ✅ Install (npm)
- ✅ Update deps (npm)
- ❌ Run build
- ✅ Run build (after attempt 2)
- ❌ Run test
- ✅ Run test (after attempt 2)
- ✅ Fresh-install verification

**AI repair attempts:**
- `Run build` → ✅ fixed after 2 attempt(s)
  - Attempt 1: validation rejected — files: `client/.env`
    > The root cause is that `babel-loader@8.4.1` in the root `node_modules` conflicts with `react-scripts@3.4.0`'s expected `babel-loader@8.0.6`. The fix is to add a `SKIP_PREFLIGHT_CHECK=true` line in a `client/.env` file, which is the standard way to bypass this CRA preflight check when the conflicting package is a dev dependency of the parent project (not something we should remove since it's used by the server build tools).
    > validation: These files are .gitignored and would be silently dropped on commit: client/.env. The fix would only "work" in the temp workspace, not for fresh users. Modify a tracked file instead — e.g. inline env vars in package.json scripts ("build": "VAR=value <command>") or pin dep versions directly in package.json.
  - Attempt 2: patch applied — files: `client/package.json`
    > The build fails because react-scripts 3.4.0 expects babel-loader 8.0.6, but the root package.json has babel-loader ^8.4.1 in devDependencies which gets hoisted and conflicts. The fix is to add a SKIP_PREFLIGHT_CHECK=true setting — but since .env is gitignored, instead I'll add it to the client build script inline, or better yet create a tracked `client/.env` alternative. Since .env is gitignored, the correct approach per the constraints is to use a tracked config file. The `react-scripts` preflight check respects `SKIP_PREFLIGHT_CHECK` as an env var, so I can inline it in the build script in client/package.json.
- `Run test` → ✅ fixed after 2 attempt(s)
  - Attempt 1: validation rejected — files: `client/.env`
    > The react-scripts preflight check detects a `babel-loader` version conflict: react-scripts@3.4.0 expects version 8.0.6 but finds 8.4.1 in the parent node_modules. The fix is to add `SKIP_PREFLIGHT_CHECK=true` to a `.env` file in the client directory, which is what the error message itself recommends and is the standard approach for this kind of transitive dependency conflict in a monorepo setup.
    > validation: These files are .gitignored and would be silently dropped on commit: client/.env. The fix would only "work" in the temp workspace, not for fresh users. Modify a tracked file instead — e.g. inline env vars in package.json scripts ("build": "VAR=value <command>") or pin dep versions directly in package.json.
  - Attempt 2: patch applied — files: `client/package.json`
    > The root cause is that a `babel-loader@8.4.1` installed in the root `node_modules` conflicts with `react-scripts@3.4.0`'s preflight check which expects `babel-loader@8.0.6`. The fix is to add `SKIP_PREFLIGHT_CHECK=true` to the test script (like it's already done for the build script), since we can't use a `.env` file (gitignored). This is the same approach already used in the `build` script.

## Verify before merging
- Pull the branch locally
- Run install + tests against your real environment
- **Read the AI repair attempts carefully** — Claude wrote those patches and a human review matters
- If everything looks good, mark the PR ready for review and merge

---
_Opened by [repo-reviver](https://github.com/bradtraversy/repo-reviver-cli)._